### PR TITLE
1.3 Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'ua.starman'
-version = '1.2'
+version = '1.3'
 
 repositories {
     mavenCentral()
@@ -19,6 +19,8 @@ repositories {
 
 dependencies {
     compileOnly "org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT"
+    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
+    implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
 }
 
 def targetJavaVersion = 17

--- a/src/main/java/ua/starman/easylogin/EasyAuth.java
+++ b/src/main/java/ua/starman/easylogin/EasyAuth.java
@@ -1,20 +1,26 @@
 package ua.starman.easylogin;
 
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
-import ua.starman.easylogin.auther.AuthWorker;
 import ua.starman.easylogin.commands.AuthCommand;
 import ua.starman.easylogin.commands.LoginCommand;
 import ua.starman.easylogin.commands.RegisterCommand;
 import ua.starman.easylogin.events.AuthEvents;
+import ua.starman.easylogin.filters.CommandsFilter;
+import ua.starman.easylogin.filters.Log4JFilter;
 import ua.starman.easylogin.utils.UpdateChecker;
 import ua.starman.easylogin.utils.Utils;
 import ua.starman.easylogin.utils.Vars;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Objects;
+import java.util.logging.*;
 
 public final class EasyAuth extends JavaPlugin {
     @Override
     public void onEnable() {
+        setupConsoleFilter(getLogger());
+
         // Plugin startup logic
         saveDefaultConfig();
 
@@ -40,5 +46,28 @@ public final class EasyAuth extends JavaPlugin {
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    public static void setupConsoleFilter(Logger logger) {
+        // Try to set the log4j filter
+        try {
+            Class.forName("org.apache.logging.log4j.core.filter.AbstractFilter");
+            setLog4JFilter();
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            // log4j is not available
+            logger.info("You're using Minecraft 1.6.x or older, Log4J support will be disabled");
+            CommandsFilter filter = new CommandsFilter();
+            logger.setFilter(filter);
+            Bukkit.getLogger().setFilter(filter);
+            Logger.getLogger("Minecraft").setFilter(filter);
+        }
+    }
+
+    // Set the console filter to remove the passwords
+    private static void setLog4JFilter() {
+        org.apache.logging.log4j.core.Logger logger;
+
+        logger = (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
+        logger.addFilter(new Log4JFilter());
     }
 }

--- a/src/main/java/ua/starman/easylogin/auther/AuthWorker.java
+++ b/src/main/java/ua/starman/easylogin/auther/AuthWorker.java
@@ -36,8 +36,6 @@ public class AuthWorker {
         return playerData.password.equals(true_pass);
     }
 
-
-
     public static void loginCancel(Player player, Event event) {
         List<MetadataValue> metadataBlockedList = player.getMetadata("auth_block");
         for (MetadataValue metadataBlocked : metadataBlockedList) {
@@ -46,16 +44,11 @@ public class AuthWorker {
                     ((Cancellable) event).setCancelled(true);
                 }
             }
-
             List<MetadataValue> metadataNeedRegisterList = player.getMetadata("auth_register");
 
-
-
             if (metadataNeedRegisterList.isEmpty() && metadataBlocked.asBoolean()) {
-                Vars.plugin.getLogger().info(metadataBlocked.asString() + " need lo");
                 player.sendMessage(Utils.parseMessage(ChatColor.RED + "Enter /login <password>"));
             } else if (!metadataNeedRegisterList.isEmpty() && metadataBlocked.asBoolean()){
-                Vars.plugin.getLogger().info(String.valueOf(metadataNeedRegisterList.isEmpty()));
                 player.sendMessage(Utils.parseMessage(ChatColor.RED + "Enter /register <password> <password>"));
             }
 
@@ -70,6 +63,4 @@ public class AuthWorker {
             return null;
         }
     }
-
-
 }

--- a/src/main/java/ua/starman/easylogin/auther/PlayerData.java
+++ b/src/main/java/ua/starman/easylogin/auther/PlayerData.java
@@ -41,14 +41,23 @@ public class PlayerData {
 
     public static boolean check(UUID playerUUID) {
         File playerSaveFile = new File(Vars.dataDir, playerUUID + ".json");
+        File playerSaveFileOld = new File(Vars.dataDirOld, playerUUID + ".json");
 
-        return playerSaveFile.exists();
+        return playerSaveFile.exists() || playerSaveFileOld.exists();
     }
 
     public static PlayerData get(UUID playerUUID) {
         File playerSaveFile = new File(Vars.dataDir, playerUUID.toString() + ".json");
+        File playerSaveFileOld = new File(Vars.dataDirOld, playerUUID + ".json");
+        File file;
 
-        try (FileReader reader = new FileReader(playerSaveFile)) {
+        if (!playerSaveFile.exists()) {
+            file = playerSaveFileOld;
+        } else {
+            file = playerSaveFile;
+        }
+
+        try (FileReader reader = new FileReader(file)) {
             return gson.fromJson(reader, PlayerData.class);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/ua/starman/easylogin/commands/AuthCommand.java
+++ b/src/main/java/ua/starman/easylogin/commands/AuthCommand.java
@@ -8,11 +8,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import ua.starman.easylogin.EasyAuth;
 import ua.starman.easylogin.auther.PlayerData;
+import ua.starman.easylogin.utils.Utils;
 import ua.starman.easylogin.utils.Vars;
 
 public class AuthCommand implements CommandExecutor {
-    static Plugin plugin = EasyAuth.getPlugin(EasyAuth.class);
-    private final Vars vars = new Vars();
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
@@ -24,12 +23,14 @@ public class AuthCommand implements CommandExecutor {
             Player player = sender.getServer().getPlayer(args[0]);
             if (player != null) {
                 playerData = PlayerData.get(player.getUniqueId());
+            } else {
+                sender.sendMessage(Utils.parseMessage("This player is not registered"));
+                return false;
             }
         } else {
             // TODO
             return false;
         }
-
 
         assert playerData != null;
 
@@ -38,7 +39,7 @@ public class AuthCommand implements CommandExecutor {
                 ChatColor.AQUA + "UUID: " + ChatColor.RESET + playerData.uuid,
                 ChatColor.AQUA + "Nickname: " + ChatColor.RESET + playerData.name,
                 ChatColor.AQUA + "IP: " + ChatColor.RESET + playerData.ip.toString(),
-                ChatColor.AQUA + "Last login time: " + ChatColor.RESET + playerData.lastLogin.toString(),
+                ChatColor.AQUA + "Last log in time: " + ChatColor.RESET + playerData.lastLogin.toString(),
                 ChatColor.BLUE + "------------"
         );
         return false;

--- a/src/main/java/ua/starman/easylogin/events/AuthEvents.java
+++ b/src/main/java/ua/starman/easylogin/events/AuthEvents.java
@@ -12,6 +12,8 @@ import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.metadata.FixedMetadataValue;
 import ua.starman.easylogin.auther.AuthWorker;
 import ua.starman.easylogin.auther.PlayerData;
+import ua.starman.easylogin.limits.IpLimit;
+import ua.starman.easylogin.limits.TimeLimit;
 import ua.starman.easylogin.utils.Utils;
 import ua.starman.easylogin.utils.Vars;
 
@@ -26,12 +28,12 @@ public class AuthEvents implements Listener {
         if (PlayerData.check(player.getUniqueId())) {
             PlayerData playerData = PlayerData.get(player.getUniqueId());
 
-            if (!playerData.ip.equals(AuthWorker.getIPAddress(player))) {
+            if (IpLimit.working && !playerData.ip.equals(AuthWorker.getIPAddress(player))) {
                 Vars.plugin.getLogger().info(String.format("Player %s was blocked", player.getName()));
                 player.setMetadata("auth_block", new FixedMetadataValue(Vars.plugin, true));
 
                 player.sendMessage(Utils.parseMessage(ChatColor.RED + "You joined from different IP address. Use /login <password>"));
-            } else if (Duration.between(playerData.lastLogin, LocalDateTime.now()).toMinutes() >= Vars.login_time) {
+            } else if (TimeLimit.working && Duration.between(playerData.lastLogin, LocalDateTime.now()).toMinutes() >= TimeLimit.time) {
                 Vars.plugin.getLogger().info(String.format("Player %s was blocked", player.getName()));
                 player.setMetadata("auth_block", new FixedMetadataValue(Vars.plugin, true));
 

--- a/src/main/java/ua/starman/easylogin/filters/CommandsFilter.java
+++ b/src/main/java/ua/starman/easylogin/filters/CommandsFilter.java
@@ -1,0 +1,18 @@
+package ua.starman.easylogin.filters;
+
+import java.util.logging.Filter;
+import java.util.logging.LogRecord;
+
+public class CommandsFilter implements Filter {
+    @Override
+    public boolean isLoggable(LogRecord record) {
+        String message = record.getMessage();
+        if (message != null) {
+            if (message.toLowerCase().contains("/reg ") || message.toLowerCase().contains("/log ")) {
+                String playerName = record.getMessage().split(" ")[0];
+                record.setMessage(playerName + " issued an auth command");
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/ua/starman/easylogin/filters/Log4JFilter.java
+++ b/src/main/java/ua/starman/easylogin/filters/Log4JFilter.java
@@ -1,0 +1,82 @@
+package ua.starman.easylogin.filters;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.message.Message;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * @author Xephi59
+ */
+
+public class Log4JFilter extends AbstractFilter implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = -5594073755007974254L;
+
+    /**
+     * Validates a Message instance and returns the {@link Result} value
+     * depending on whether the message contains sensitive AuthMe data.
+     *
+     * @param message The Message object to verify
+     *
+     * @return The Result value
+     */
+    private static Result validateMessage(Message message) {
+        if (message == null) {
+            return Result.NEUTRAL;
+        }
+        return validateMessage(message.getFormattedMessage());
+    }
+
+    /**
+     * Validates a message and returns the {@link Result} value depending
+     * on whether the message contains sensitive AuthMe data.
+     *
+     * @param message The message to verify
+     *
+     * @return The Result value
+     */
+    private static Result validateMessage(String message) {
+        if (message != null) {
+            if (message.toLowerCase().contains("/reg") || message.toLowerCase().contains("/log")) {
+                return Result.DENY;
+            }
+        }
+
+        return Result.NEUTRAL;
+    }
+
+    @Override
+    public Result filter(LogEvent event) {
+        Message candidate = null;
+        if (event != null) {
+            candidate = event.getMessage();
+        }
+        return validateMessage(candidate);
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, Message msg, Throwable t) {
+        return validateMessage(msg);
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, String msg, Object... params) {
+        return validateMessage(msg);
+    }
+
+    @Override
+    public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
+        String candidate = null;
+        if (msg != null) {
+            candidate = msg.toString();
+        }
+        return validateMessage(candidate);
+    }
+}

--- a/src/main/java/ua/starman/easylogin/limits/IpLimit.java
+++ b/src/main/java/ua/starman/easylogin/limits/IpLimit.java
@@ -1,0 +1,7 @@
+package ua.starman.easylogin.limits;
+
+import ua.starman.easylogin.utils.Vars;
+
+public class IpLimit {
+    public static boolean working = Vars.plugin.getConfig().getBoolean("limits.ip.working");
+}

--- a/src/main/java/ua/starman/easylogin/limits/TimeLimit.java
+++ b/src/main/java/ua/starman/easylogin/limits/TimeLimit.java
@@ -1,0 +1,8 @@
+package ua.starman.easylogin.limits;
+
+import ua.starman.easylogin.utils.Vars;
+
+public class TimeLimit {
+    public static boolean working = Vars.plugin.getConfig().getBoolean("limits.time.working");
+    public static int time = Vars.plugin.getConfig().getInt("limits.time.login_time");
+}

--- a/src/main/java/ua/starman/easylogin/utils/Vars.java
+++ b/src/main/java/ua/starman/easylogin/utils/Vars.java
@@ -3,6 +3,7 @@ package ua.starman.easylogin.utils;
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.Plugin;
 import ua.starman.easylogin.EasyAuth;
+import ua.starman.easylogin.limits.TimeLimit;
 
 import java.io.File;
 import java.util.Objects;
@@ -11,6 +12,6 @@ public class Vars {
     public static Plugin plugin = EasyAuth.getPlugin(EasyAuth.class);
     public static String pluginTab = plugin.getConfig().getString("plugin.tab");
     public static File dataDir = new File(Objects.requireNonNull(plugin.getConfig().getString("data.dir")));
+    public static File dataDirOld = new File("plugins/EasyAuth/player-data");
     public static String encode = plugin.getConfig().getString("data.method");
-    public static Integer login_time = plugin.getConfig().getInt("limits.login_time");
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,11 +8,18 @@ plugin:
 # How and where player data will be stored
 data:
   # Where to store player data
-  dir: "plugins/EasyAuth/player-data"
+  dir: "world/playerdata/easy-auth"
   # SHA256 - encoding data in SHA256. no - not encoding data at all (Not recommended)
   method: "SHA256"
 
 # Limits that will be used to players
 limits:
-  # How much plugin must wait before asking for re-log in minutes
-  login_time: 30
+  # Time difference limit
+  time:
+    # If false - will not check time difference on player join
+    working: true
+    # How much plugin must wait before asking for re-log in minutes
+    login_time: 60
+  ip:
+    # If false - will not check IP difference on player join
+    working: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,7 +19,7 @@ limits:
     # If false - will not check time difference on player join
     working: true
     # How much plugin must wait before asking for re-log in minutes
-    login_time: 60
+    login_time: 1
   ip:
     # If false - will not check IP difference on player join
     working: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,11 @@ api-version: '1.21'
 commands:
   login:
     description: 'Command to log in'
+    aliases:
+      - 'log'
   register:
     description: 'Command to register'
+    aliases:
+      - 'reg'
   auth:
     description: 'Command to check auth data'


### PR DESCRIPTION
- Auth commands now not displaying in console logs
- Base data dir was changed to "world/playerdata/easy-auth", so it wil be easy to wipe server. (You don't need to transfer data from old default path. It will do it automaticly on next player auth)
- Config was improved, so now checks configuration is more flexible
- Junk console logs spam from not authed players was fixed
- Fixed error when trying to use /auth command with not registered player
- Added aliases for `/register`/`/login` commands (`/reg`/`/log`)